### PR TITLE
fix: correct 'this' binding issue in setInterval function call

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -1,7 +1,7 @@
 {
   "FRAMEWORK": {
     "NAME": "Beat",
-    "VERSION": "6.1.9"
+    "VERSION": "6.1.12"
   },
   "SERVER": {
     "PORT": "3601",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@linkloom/loom-svc-js",
   "title": "Loom service",
   "description": "Another Node.js Server framework to create microservices or huge monoliths.",
-  "version": "6.1.11",
+  "version": "6.1.12",
   "homepage": "https://github.com/link-loom",
   "author": "Camilo Alexander Rodriguez Cuaran <camiepisode@outlook.com>",
   "repository": {

--- a/src/core/functions.manager.js
+++ b/src/core/functions.manager.js
@@ -111,7 +111,11 @@ class FunctionsManager {
           setTimeout(() => {
             /* Setup next ticks */
             setInterval(
-              this._functions.timed[functionName].run,
+              () => {
+                this._functions.timed[functionName].run.bind(
+                  this._functions.timed[functionName],
+                )();
+              },
               this._moment
                 .duration(
                   +`${functionDefinition.intervalTime}`,


### PR DESCRIPTION
`This` commit fixes a critical issue where the server was breaking due to improper 'this' binding within a setInterval function call. Previously, the .run() method was being invoked without the correct context, causing it to lose reference to the class instance and failing to recognize the this.getStatus() method within its context.

The solution involves adding a .bind() to ensure that the .run() method retains the proper 'this' reference, as shown below:

```javascript
setInterval(
  () => {
    this._functions.timed[functionName].run.bind(
      this._functions.timed[functionName],
    )();
  },
  this._moment
    .duration(
      +`${functionDefinition.intervalTime}`,
      `${functionDefinition.intervalMeasure}`,
    )
    .as('milliseconds'),
);