### PR TITLE
Fix: Set default status to 200 in #handleRoute

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -1,7 +1,7 @@
 {
   "FRAMEWORK": {
     "NAME": "Loom",
-    "VERSION": "6.1.12"
+    "VERSION": "6.1.13"
   },
   "SERVER": {
     "PORT": "3601",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@linkloom/loom-svc-js",
   "title": "Loom service",
   "description": "Another Node.js Server framework to create microservices or huge monoliths.",
-  "version": "6.1.12",
+  "version": "6.1.13",
   "homepage": "https://github.com/link-loom",
   "author": "Camilo Alexander Rodriguez Cuaran <camiepisode@outlook.com>",
   "repository": {

--- a/src/core/api.manager.js
+++ b/src/core/api.manager.js
@@ -89,7 +89,7 @@ class ApiManager {
 
     const serviceResponse = await route[endpoint.handler]({ params, req, res });
 
-    res.status(serviceResponse.status || 200).json(serviceResponse);
+    res.status(serviceResponse?.status || 200).json(serviceResponse);
   }
 
   #buildApiEndpoints() {

--- a/src/core/api.manager.js
+++ b/src/core/api.manager.js
@@ -89,7 +89,7 @@ class ApiManager {
 
     const serviceResponse = await route[endpoint.handler]({ params, req, res });
 
-    res.status(serviceResponse.status).json(serviceResponse);
+    res.status(serviceResponse.status || 200).json(serviceResponse);
   }
 
   #buildApiEndpoints() {


### PR DESCRIPTION
- Added a default status of 200 to serviceResponse in the #handleRoute method to handle cases where the status is not explicitly set by endpoint handlers.